### PR TITLE
Add private clients summary

### DIFF
--- a/companyClientManagement.js
+++ b/companyClientManagement.js
@@ -105,3 +105,85 @@ function deleteClient(clientId) {
         }
     }
 }
+
+// Gestione clienti privati
+function addPrivateClient() {
+    const firstName = document.getElementById('privateFirstName').value.trim();
+    const lastName = document.getElementById('privateLastName').value.trim();
+    const phone = document.getElementById('privatePhone').value.trim();
+    const email = document.getElementById('privateEmail').value.trim();
+
+    if (!firstName || !lastName) {
+        alert('Inserisci nome e cognome');
+        return;
+    }
+
+    const client = {
+        id: Date.now(),
+        firstName,
+        lastName,
+        phone,
+        email
+    };
+
+    appData.privateClients.push(client);
+    saveDataToLocalStorage();
+    closeModal('addPrivateClientModal');
+    renderPrivateClients();
+}
+
+function deletePrivateClient(clientId) {
+    if (confirm('Sei sicuro di voler eliminare questo cliente?')) {
+        appData.privateClients = appData.privateClients.filter(c => c.id !== clientId);
+        saveDataToLocalStorage();
+        renderPrivateClients();
+    }
+}
+
+function showAddPrivateClientModal() {
+    document.getElementById('privateFirstName').value = '';
+    document.getElementById('privateLastName').value = '';
+    document.getElementById('privatePhone').value = '';
+    document.getElementById('privateEmail').value = '';
+    showModal('addPrivateClientModal');
+}
+
+function renderPrivateClients() {
+    const grid = document.getElementById('privateClientGrid');
+    if (!grid) return;
+    grid.innerHTML = '';
+
+    if (appData.privateClients.length === 0) {
+        grid.innerHTML = '<p class="text-center text-muted">Nessun cliente privato aggiunto.</p>';
+    } else {
+        appData.privateClients.forEach(client => {
+            const card = document.createElement('div');
+            card.className = 'client-card';
+            card.innerHTML = `
+                <button class="delete-btn" onclick="event.stopPropagation(); deletePrivateClient(${client.id})">×</button>
+                <h3>${client.firstName} ${client.lastName}</h3>
+                <p>${client.phone || ''}</p>
+                <p>${client.email || ''}</p>
+            `;
+            grid.appendChild(card);
+        });
+    }
+
+    const filter = document.getElementById('privateClientSearch')?.value.toLowerCase() || '';
+    const tbody = document.querySelector('#privateClientTable tbody');
+    if (!tbody) return;
+    tbody.innerHTML = '';
+
+    const filtered = appData.privateClients.filter(c =>
+        `${c.firstName} ${c.lastName}`.toLowerCase().includes(filter)
+    );
+
+    filtered.forEach(c => {
+        const row = document.createElement('tr');
+        row.innerHTML = `<td>${c.firstName}</td><td>${c.lastName}</td><td>${c.phone || ''}</td><td>${c.email || ''}</td>`;
+        tbody.appendChild(row);
+    });
+
+    const countEl = document.getElementById('privateClientCount');
+    if (countEl) countEl.textContent = `Totale clienti privati: ${filtered.length}`;
+}

--- a/data.js
+++ b/data.js
@@ -1,6 +1,7 @@
 // data.js
 let appData = {
     companies: [],
+    privateClients: [],
     categories: ['Leadership', 'Comunicazione', 'Gestione del tempo', 'Problem solving', 'Team building', 'Resilienza', 'Creatività'],
     tags: ['Urgente', 'In progress', 'Completato', 'Da rivedere', 'Alta Priorità', 'Bassa Priorità'],
     globalTodos: [],

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
                 <div class="nav-tab active" data-section="dashboard">Dashboard</div>
                 <div class="nav-tab" data-section="companies">Aziende</div>
                 <div class="nav-tab" data-section="sessions">Sessioni</div>
+                <div class="nav-tab" data-section="private">Privati</div>
                 <div class="nav-tab" data-section="settings">Impostazioni</div>
             </nav>
             <div class="sidebar-footer">
@@ -163,6 +164,32 @@
                 </div>
             </section>
 
+            <section id="private" class="content-section">
+                <div class="card header-card">
+                    <h2>Gestione Clienti Privati</h2>
+                    <button class="btn btn-primary" onclick="showAddPrivateClientModal()">Aggiungi Cliente</button>
+                </div>
+                <div class="client-grid" id="privateClientGrid"></div>
+                <div class="card">
+                    <h3>Riepilogo Clienti</h3>
+                    <div class="form-group">
+                        <input type="text" id="privateClientSearch" class="form-control" placeholder="Filtra per nome..." oninput="renderPrivateClients()">
+                    </div>
+                    <div id="privateClientCount" class="mb-2"></div>
+                    <table id="privateClientTable" class="summary-table">
+                        <thead>
+                            <tr>
+                                <th>Nome</th>
+                                <th>Cognome</th>
+                                <th>Telefono</th>
+                                <th>E-mail</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </section>
+
             <section id="settings" class="content-section">
                 <div class="settings-grid">
                     <div class="card">
@@ -241,6 +268,32 @@
         </div>
     </div>
 
+    <div id="addPrivateClientModal" class="modal">
+        <div class="modal-content">
+            <h2>Aggiungi Cliente Privato</h2>
+            <div class="form-group">
+                <label for="privateFirstName">Nome</label>
+                <input type="text" id="privateFirstName" class="form-control" placeholder="Nome...">
+            </div>
+            <div class="form-group">
+                <label for="privateLastName">Cognome</label>
+                <input type="text" id="privateLastName" class="form-control" placeholder="Cognome...">
+            </div>
+            <div class="form-group">
+                <label for="privatePhone">Telefono</label>
+                <input type="text" id="privatePhone" class="form-control" placeholder="Telefono...">
+            </div>
+            <div class="form-group">
+                <label for="privateEmail">E-mail</label>
+                <input type="email" id="privateEmail" class="form-control" placeholder="E-mail...">
+            </div>
+            <div class="modal-actions">
+                <button class="btn btn-primary" onclick="addPrivateClient()">Salva</button>
+                <button class="btn btn-secondary" onclick="closeModal('addPrivateClientModal')">Annulla</button>
+            </div>
+        </div>
+    </div>
+
     <script src="data.js"></script>
     <script src="utils.js"></script>
     <script src="dom.js"></script>
@@ -292,6 +345,8 @@
                 renderCompanies();
             } else if (sectionId === 'sessions') {
                 loadCompaniesForSessionSelection();
+            } else if (sectionId === 'private') {
+                renderPrivateClients();
             } else if (sectionId === 'dashboard') {
                 updateDashboard();
             }

--- a/style.css
+++ b/style.css
@@ -354,6 +354,19 @@ body {
     box-shadow: 0 2px 8px rgba(60, 64, 67, 0.15);
 }
 
+/* Table summary for private clients */
+.summary-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 10px;
+}
+.summary-table th,
+.summary-table td {
+    padding: 8px;
+    border: 1px solid #dadce0;
+    text-align: left;
+}
+
 .stat-card h3 {
     color: #70757a; /* Colore testo più chiaro */
     font-size: 0.8em; /* Dimensione più piccola */


### PR DESCRIPTION
## Summary
- support `privateClients` in data storage
- manage private clients in `companyClientManagement.js`
- add Private section with table of clients
- style summary table

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6846e7263c7c8324a92b5a077ff06bfb