### PR TITLE
Add private client selection in sessions

### DIFF
--- a/data.js
+++ b/data.js
@@ -6,5 +6,6 @@ let appData = {
     tags: ['Urgente', 'In progress', 'Completato', 'Da rivedere', 'Alta Priorità', 'Bassa Priorità'],
     globalTodos: [],
     currentCompanyId: null,
-    currentClientId: null
+    currentClientId: null,
+    currentSessionType: 'company'
 };

--- a/index.html
+++ b/index.html
@@ -73,6 +73,14 @@
             </section>
 
             <section id="sessions" class="content-section">
+                <div class="card" id="sessionTypeCard">
+                    <h2>Tipo di Cliente</h2>
+                    <select id="sessionTypeSelect" class="form-select">
+                        <option value="company">Azienda</option>
+                        <option value="private">Privato</option>
+                    </select>
+                </div>
+
                 <div class="card" id="sessionCompanySelectionCard">
                     <h2>Seleziona Azienda</h2>
                     <select id="sessionCompanySelect" class="form-select">
@@ -84,6 +92,11 @@
                 <div class="card" id="sessionClientSelectionCard" style="display: none;">
                     <h2>Seleziona Cliente</h2>
                     <div class="client-select-grid" id="clientSelectGrid"></div>
+                </div>
+
+                <div class="card" id="sessionPrivateSelectionCard" style="display: none;">
+                    <h2>Seleziona Cliente Privato</h2>
+                    <div class="client-select-grid" id="sessionPrivateClientGrid"></div>
                 </div>
 
                 <div id="clientSessionView" style="display: none;">
@@ -160,6 +173,15 @@
                         <button class="btn btn-secondary" onclick="window.print()">Stampa Scheda Cliente</button>
                         <button class="btn btn-info" onclick="generateHRReport()">Genera Report (PDF)</button>
                         <button class="btn btn-warning" onclick="saveClientData()">Salva Modifiche</button>
+                    </div>
+                </div>
+
+                <div id="privateClientView" style="display: none;">
+                    <div class="card client-info-card">
+                        <div class="client-header">
+                            <h2 id="privateClientNameDisplay"></h2>
+                        </div>
+                        <div id="privateClientInfoDisplay"></div>
                     </div>
                 </div>
             </section>
@@ -318,7 +340,17 @@
             document.querySelectorAll('.modal').forEach(modal => {
                 modal.style.display = 'none';
             });
-            showSection('dashboard'); 
+            const modeSelect = document.getElementById('sessionTypeSelect');
+            if (modeSelect) {
+                modeSelect.addEventListener('change', () => {
+                    if (modeSelect.value === 'private') {
+                        loadPrivateClientsForSessionSelection();
+                    } else {
+                        loadCompaniesForSessionSelection();
+                    }
+                });
+            }
+            showSection('dashboard');
         }
 
         function setupNavigation() {
@@ -344,7 +376,12 @@
             if (sectionId === 'companies') {
                 renderCompanies();
             } else if (sectionId === 'sessions') {
-                loadCompaniesForSessionSelection();
+                const modeSelect = document.getElementById('sessionTypeSelect');
+                if (modeSelect && modeSelect.value === 'private') {
+                    loadPrivateClientsForSessionSelection();
+                } else {
+                    loadCompaniesForSessionSelection();
+                }
             } else if (sectionId === 'private') {
                 renderPrivateClients();
             } else if (sectionId === 'dashboard') {

--- a/sessionManagement.js
+++ b/sessionManagement.js
@@ -2,6 +2,7 @@
 // Funzioni per la gestione delle sessioni e del profilo cliente
 
 function loadCompaniesForSessionSelection() {
+    appData.currentSessionType = 'company';
     const select = document.getElementById('sessionCompanySelect');
     select.innerHTML = '<option value="">Seleziona un\'azienda...</option>';
     
@@ -40,6 +41,44 @@ function loadCompaniesForSessionSelection() {
     document.getElementById('sessionCompanySelectionCard').style.display = 'block';
     document.getElementById('sessionClientSelectionCard').style.display = 'none';
     document.getElementById('clientSessionView').style.display = 'none';
+}
+
+function loadPrivateClientsForSessionSelection() {
+    appData.currentSessionType = 'private';
+    const grid = document.getElementById('sessionPrivateClientGrid');
+    grid.innerHTML = '';
+
+    if (appData.privateClients.length === 0) {
+        grid.innerHTML = '<p class="text-center">Nessun cliente privato disponibile.</p>';
+    } else {
+        appData.privateClients.forEach(client => {
+            const card = document.createElement('div');
+            card.className = 'client-select-card';
+            card.innerHTML = `<h3>${client.firstName} ${client.lastName}</h3>`;
+            card.onclick = () => showPrivateClientCard(client.id);
+            grid.appendChild(card);
+        });
+    }
+
+    document.getElementById('sessionPrivateSelectionCard').style.display = 'block';
+    document.getElementById('sessionCompanySelectionCard').style.display = 'none';
+    document.getElementById('sessionClientSelectionCard').style.display = 'none';
+    document.getElementById('clientSessionView').style.display = 'none';
+    document.getElementById('privateClientView').style.display = 'none';
+}
+
+function showPrivateClientCard(clientId) {
+    const client = appData.privateClients.find(c => c.id === clientId);
+    if (!client) return;
+
+    appData.currentClientId = clientId;
+    document.getElementById('privateClientNameDisplay').textContent = `${client.firstName} ${client.lastName}`;
+    document.getElementById('privateClientInfoDisplay').innerHTML = `
+        <p><strong>Telefono:</strong> ${client.phone || ''}</p>
+        <p><strong>Email:</strong> ${client.email || ''}</p>`;
+
+    document.getElementById('privateClientView').style.display = 'block';
+    document.getElementById('sessionPrivateSelectionCard').style.display = 'none';
 }
 
 


### PR DESCRIPTION
## Summary
- let session mode choose between company or private client
- show list of private clients in sessions
- allow viewing a private client's contact card
- handle session type selection in scripts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846f36a32608324ac78fed00b4f6e51