### PR TITLE
Fix session view toggle

### DIFF
--- a/sessionManagement.js
+++ b/sessionManagement.js
@@ -39,8 +39,10 @@ function loadCompaniesForSessionSelection() {
 
     // Show company selection card, hide client selection and client session view
     document.getElementById('sessionCompanySelectionCard').style.display = 'block';
+    document.getElementById('sessionPrivateSelectionCard').style.display = 'none';
     document.getElementById('sessionClientSelectionCard').style.display = 'none';
     document.getElementById('clientSessionView').style.display = 'none';
+    document.getElementById('privateClientView').style.display = 'none';
 }
 
 function loadPrivateClientsForSessionSelection() {


### PR DESCRIPTION
## Summary
- hide private client elements when switching session type back to companies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846f5afdcb48324aa92bacda5c783fc