### PR TITLE
Enable full session view for private clients

### DIFF
--- a/companyClientManagement.js
+++ b/companyClientManagement.js
@@ -112,6 +112,8 @@ function addPrivateClient() {
     const lastName = document.getElementById('privateLastName').value.trim();
     const phone = document.getElementById('privatePhone').value.trim();
     const email = document.getElementById('privateEmail').value.trim();
+    const plannedSessions = parseInt(document.getElementById('privatePlannedSessions').value);
+    const hoursPerSession = parseFloat(document.getElementById('privateHoursPerSession').value);
 
     if (!firstName || !lastName) {
         alert('Inserisci nome e cognome');
@@ -123,7 +125,19 @@ function addPrivateClient() {
         firstName,
         lastName,
         phone,
-        email
+        email,
+        plannedSessions: isNaN(plannedSessions) ? 10 : plannedSessions,
+        hoursPerSession: isNaN(hoursPerSession) ? 1.5 : hoursPerSession,
+        completedSessions: 0,
+        profile: {
+            habits: [],
+            strengths: [],
+            improvementAreas: [],
+            compliance: 'good'
+        },
+        masterElements: [],
+        todos: [],
+        sessionHistory: []
     };
 
     appData.privateClients.push(client);
@@ -145,6 +159,8 @@ function showAddPrivateClientModal() {
     document.getElementById('privateLastName').value = '';
     document.getElementById('privatePhone').value = '';
     document.getElementById('privateEmail').value = '';
+    document.getElementById('privatePlannedSessions').value = '10';
+    document.getElementById('privateHoursPerSession').value = '1.5';
     showModal('addPrivateClientModal');
 }
 

--- a/dashboardManagement.js
+++ b/dashboardManagement.js
@@ -47,8 +47,8 @@ function addGlobalTodo() {
 
 function toggleTodo(type, index) {
     if (type === 'client') {
-        const company = appData.companies.find(c => c.id === appData.currentCompanyId);
-        const client = company.clients.find(c => c.id === appData.currentClientId);
+        const client = getCurrentClient();
+        if (!client) return;
         client.todos[index].completed = !client.todos[index].completed;
         displayClientTodos(client);
     } else {
@@ -60,8 +60,8 @@ function toggleTodo(type, index) {
 
 function removeTodo(type, index) {
     if (type === 'client') {
-        const company = appData.companies.find(c => c.id === appData.currentCompanyId);
-        const client = company.clients.find(c => c.id === appData.currentClientId);
+        const client = getCurrentClient();
+        if (!client) return;
         if (confirm('Sei sicuro di voler rimuovere questo To-Do per il cliente?')) {
             client.todos.splice(index, 1);
             displayClientTodos(client);

--- a/index.html
+++ b/index.html
@@ -309,6 +309,14 @@
                 <label for="privateEmail">E-mail</label>
                 <input type="email" id="privateEmail" class="form-control" placeholder="E-mail...">
             </div>
+            <div class="form-group">
+                <label for="privatePlannedSessions">Numero di sessioni programmate</label>
+                <input type="number" id="privatePlannedSessions" min="1" value="10" class="form-control">
+            </div>
+            <div class="form-group">
+                <label for="privateHoursPerSession">Ore per sessione</label>
+                <input type="number" id="privateHoursPerSession" min="0.5" step="0.5" value="1.5" class="form-control">
+            </div>
             <div class="modal-actions">
                 <button class="btn btn-primary" onclick="addPrivateClient()">Salva</button>
                 <button class="btn btn-secondary" onclick="closeModal('addPrivateClientModal')">Annulla</button>

--- a/utils.js
+++ b/utils.js
@@ -53,3 +53,11 @@ function handleImport(event) {
     };
     reader.readAsText(file);
 }
+
+function getCurrentClient() {
+    if (appData.currentSessionType === 'private') {
+        return appData.privateClients.find(c => c.id === appData.currentClientId) || null;
+    }
+    const company = appData.companies.find(c => c.id === appData.currentCompanyId);
+    return company ? company.clients.find(c => c.id === appData.currentClientId) : null;
+}


### PR DESCRIPTION
## Summary
- add planned sessions and hours per session to private client modal
- store full profile data for private clients
- unify session handling using `getCurrentClient`
- allow private clients to use the same session view as company clients

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846f7eb95ac832492eaa0225e4298f1